### PR TITLE
Feature/duplicate gitignore

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -1,5 +1,0 @@
-.idea
-.idea/**
-vendor
-composer.lock
-/tests/data

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-composer.lock
+.idea
+.idea/**
 vendor
+composer.lock
+/tests/data


### PR DESCRIPTION
Due to the presence of .gitignore and .gitIgnore, it is not possible to "git clone" properly in a windows environment.
"composer require" cannot be performed normally even in Docker on Windows.